### PR TITLE
Add missing translate() calls to strings

### DIFF
--- a/src/app/(tabs)/authors/_layout.tsx
+++ b/src/app/(tabs)/authors/_layout.tsx
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n';
 import { useThemedStyles } from '@/lib/theme';
 import { Stack } from 'expo-router';
 
@@ -12,7 +13,7 @@ export default function AuthorsLayout() {
       headerTitleStyle: { color: header.titleColor },
       headerShadowVisible: false,
     }}>
-      <Stack.Screen name="index" options={{ title: 'Authors' }} />
+      <Stack.Screen name="index" options={{ title: translate('tabs.authors') }} />
     </Stack>
   );
 }

--- a/src/app/(tabs)/home/_layout.tsx
+++ b/src/app/(tabs)/home/_layout.tsx
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n';
 import { useThemedStyles } from '@/lib/theme';
 import { Stack } from 'expo-router';
 
@@ -12,7 +13,7 @@ export default function HomeLayout() {
       headerTitleStyle: { color: header.titleColor },
       headerShadowVisible: false,
     }}>
-      <Stack.Screen name="index" options={{ title: 'Home' }} />
+      <Stack.Screen name="index" options={{ title: translate('tabs.home') }} />
       <Stack.Screen name="item/[itemId]" options={{ headerTitle: '', headerBackButtonDisplayMode: 'minimal' }} />
     </Stack>
   );

--- a/src/app/(tabs)/home/index.tsx
+++ b/src/app/(tabs)/home/index.tsx
@@ -159,7 +159,7 @@ export default function HomeScreen() {
 
     return (
       <Pressable onPress={toggleLayout} style={buttonStyle}>
-        <Text style={textStyle}>{homeLayout === "list" ? "Cover" : "List"}</Text>
+        <Text style={textStyle}>{homeLayout === "list" ? translate("common.cover") : translate("common.list")}</Text>
       </Pressable>
     );
   }, [homeLayout, toggleLayout, isDark]);

--- a/src/app/(tabs)/series/_layout.tsx
+++ b/src/app/(tabs)/series/_layout.tsx
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n';
 import { useThemedStyles } from '@/lib/theme';
 import { Stack } from 'expo-router';
 
@@ -12,8 +13,8 @@ export default function SeriesLayout() {
       headerTitleStyle: { color: header.titleColor },
       headerShadowVisible: false,
     }}>
-      <Stack.Screen name="index" options={{ title: 'Series' }} />
-      <Stack.Screen name="[seriesId]/index" options={{ title: 'Series' }} />
+      <Stack.Screen name="index" options={{ title: translate('tabs.series') }} />
+      <Stack.Screen name="[seriesId]/index" options={{ title: translate('tabs.series') }} />
       <Stack.Screen name="[seriesId]/item/[itemId]" options={{ headerTitle: '', headerBackButtonDisplayMode: 'minimal' }} />
     </Stack>
   );

--- a/src/components/library/LibraryItemDetail.tsx
+++ b/src/components/library/LibraryItemDetail.tsx
@@ -804,7 +804,7 @@ export default function LibraryItemDetail({ itemId, onTitleChange }: LibraryItem
 
         {/* Collapsible Audio Files */}
         {audioFiles.length > 0 && (
-          <CollapsibleSection title={`Audio Files (${audioFiles.length})`}>
+          <CollapsibleSection title={translate("libraryItem.audioFiles", { count: audioFiles.length })}>
             {audioFiles.map((file, index) => (
               <View
                 key={file.id}

--- a/src/components/library/LibraryItemDetail/ChapterList.tsx
+++ b/src/components/library/LibraryItemDetail/ChapterList.tsx
@@ -1,5 +1,6 @@
 import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
 import { getPlayedChapters, getUpcomingChapters } from "@/db/helpers/chapters";
+import { translate } from "@/i18n";
 import { formatTime } from "@/lib/helpers/formatters";
 import { useThemedStyles } from "@/lib/theme";
 import { playerService } from "@/services/PlayerService";
@@ -68,7 +69,7 @@ export default function ChapterList({
     return (
       <View>
         <Text style={[styles.text, { fontStyle: "italic", opacity: 0.7 }]}>
-          No chapters available.
+          {translate("chapters.empty")}
         </Text>
       </View>
     );
@@ -91,7 +92,7 @@ export default function ChapterList({
   };
 
   return (
-    <CollapsibleSection title={`Chapters (${chapters.length})`}>
+    <CollapsibleSection title={translate("libraryItem.chapters", { count: chapters.length })}>
       {/* Show expand button if there are played chapters hidden */}
       {playedChapters.length > 0 && !showPlayedChapters && (
         <TouchableOpacity
@@ -105,7 +106,9 @@ export default function ChapterList({
           }}
         >
           <Text style={[styles.text, { fontSize: 14, opacity: 0.7 }]}>
-            Show {playedChapters.length} Played Chapter{playedChapters.length !== 1 ? 's' : ''}
+            {playedChapters.length === 1
+              ? translate("chapters.showPlayed", { count: playedChapters.length })
+              : translate("chapters.showPlayedPlural", { count: playedChapters.length })}
           </Text>
         </TouchableOpacity>
       )}
@@ -123,7 +126,7 @@ export default function ChapterList({
           }}
         >
           <Text style={[styles.text, { fontSize: 14, opacity: 0.7 }]}>
-            Hide Played Chapters
+            {translate("chapters.hidePlayed")}
           </Text>
         </TouchableOpacity>
       )}

--- a/src/components/ui/HeaderControls.tsx
+++ b/src/components/ui/HeaderControls.tsx
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n';
 import type { SortConfig, SortField } from '@/types/store';
 import { MenuAction, MenuView } from '@react-native-menu/menu';
 import React from 'react';
@@ -22,7 +23,7 @@ export default function HeaderControls({
   onToggleViewMode,
   onSort,
   showViewToggle = true,
-  sortLabel = 'Sort',
+  sortLabel,
   viewToggleLabel,
   sortConfig,
   sortMenuActions,
@@ -42,11 +43,12 @@ export default function HeaderControls({
   };
 
   const iconColor = isDark ? '#fff' : '#000';
-  const computedViewToggleLabel = viewToggleLabel || (viewMode === 'grid' ? 'List' : 'Grid');
+  const computedSortLabel = sortLabel || translate("common.sort");
+  const computedViewToggleLabel = viewToggleLabel || (viewMode === 'grid' ? translate("common.list") : translate("common.grid"));
 
   const sortButton = (
     <Pressable onPress={onSort} style={[buttonStyle, { marginRight: 0 }]}>
-      <Text style={textStyle}>{sortLabel}</Text>
+      <Text style={textStyle}>{computedSortLabel}</Text>
     </Pressable>
   );
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -38,6 +38,10 @@ export const en = {
   "common.play": "Play",
   "common.pause": "Pause",
   "common.resume": "Resume",
+  "common.sort": "Sort",
+  "common.list": "List",
+  "common.grid": "Grid",
+  "common.cover": "Cover",
 
   // Library Screen
   "library.title": "Library",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -38,6 +38,10 @@ export const es = {
   "common.play": "Reproducir",
   "common.pause": "Pausar",
   "common.resume": "Reanudar",
+  "common.sort": "Ordenar",
+  "common.list": "Lista",
+  "common.grid": "Cuadrícula",
+  "common.cover": "Portada",
 
   // Library Screen
   "library.title": "Biblioteca",


### PR DESCRIPTION
Updated the following strings to use the translate() API:
- "chapters" and "audio files" in LibraryItemDetail
- Chapter list strings (empty state, show/hide played)
- "list", "sort", "grid", "cover" in HeaderControls and home screen
- Tab titles in layout files (Home, Series, Authors)

Added new translation keys:
- common.sort, common.list, common.grid, common.cover