### PR TITLE
Add diagnostics mode and developer screens

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,57 +1,51 @@
-name: Claude Code Review
+# name: Claude Code Review
 
-on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+# on:
+#   pull_request:
+#     types: [opened, synchronize]
 
-jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+# jobs:
+#   claude-review:
+#     # Optional: Filter by PR author
+#     # if: |
+#     #   github.event.pull_request.user.login == 'external-contributor' ||
+#     #   github.event.pull_request.user.login == 'new-developer' ||
+#     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       pull-requests: read
+#       issues: read
+#       id-token: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 1
 
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+#       - name: Run Claude Code Review
+#         id: claude-review
+#         uses: anthropics/claude-code-action@v1
+#         with:
+#           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+#           prompt: |
+#             REPO: ${{ github.repository }}
+#             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+#             Please review this pull request and provide feedback on:
+#             - Code quality and best practices
+#             - Potential bugs or issues
+#             - Performance considerations
+#             - Security concerns
+#             - Test coverage
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+#             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+#             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+#           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+#           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+#           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -85,9 +85,7 @@ const TabBarIcon = ({ config, focused, color, size }: TabBarIconProps) => {
   if (isAndroid) {
     return (
       <Ionicons
-        name={
-          focused ? config.androidIcon.selected : config.androidIcon.default
-        }
+        name={focused ? config.androidIcon.selected : config.androidIcon.default}
         size={size ?? 24}
         color={color}
       />
@@ -102,9 +100,7 @@ const TabBarIcon = ({ config, focused, color, size }: TabBarIconProps) => {
         tintColor={color}
         fallback={
           <Ionicons
-            name={
-              focused ? config.androidIcon.selected : config.androidIcon.default
-            }
+            name={focused ? config.androidIcon.selected : config.androidIcon.default}
             size={size ?? 24}
             color={color}
           />
@@ -127,7 +123,8 @@ export default function TabLayout() {
   const { initialized, isAuthenticated, loginMessage } = useAuth();
   const { tabs, isDark } = useThemedStyles();
   const errorCount = useAppStore((state) => state.logger.errorCount);
-  const showErrorBadge = errorCount > 0;
+  const diagnosticsEnabled = useAppStore((state) => state.settings.diagnosticsEnabled);
+  const showErrorBadge = errorCount > 0 && diagnosticsEnabled;
   useEffect(() => {
     if (initialized && !isAuthenticated) {
       router.push("/login");
@@ -138,9 +135,7 @@ export default function TabLayout() {
   }, []);
   useEffect(() => {
     if (loginMessage) {
-      console.log(
-        `[TabIndex] Redirecting to login due to loginMessage: ${loginMessage}`
-      );
+      console.log(`[TabIndex] Redirecting to login due to loginMessage: ${loginMessage}`);
       router.navigate("/login");
     }
   }, [loginMessage]);
@@ -180,12 +175,7 @@ export default function TabLayout() {
                     backgroundColor: tabs.badgeBackgroundColor,
                   },
                   tabBarIcon: ({ focused, color, size }) => (
-                    <TabBarIcon
-                      config={tab}
-                      focused={focused}
-                      color={color}
-                      size={size}
-                    />
+                    <TabBarIcon config={tab} focused={focused} color={color} size={size} />
                   ),
                 }}
               />
@@ -199,9 +189,7 @@ export default function TabLayout() {
   return (
     <View style={{ flex: 1 }}>
       <NativeTabs
-        blurEffect={
-          isDark ? "systemChromeMaterialDark" : "systemChromeMaterialLight"
-        }
+        blurEffect={isDark ? "systemChromeMaterialDark" : "systemChromeMaterialLight"}
         backgroundColor={tabs.backgroundColor}
         iconColor={tabs.iconColor}
         tintColor={tabs.selectedIconColor}
@@ -226,12 +214,10 @@ export default function TabLayout() {
                 labelStyle: { color: tabs.labelColor },
                 selectedLabelStyle: { color: tabs.selectedLabelColor },
                 backgroundColor: tabs.backgroundColor,
-                badgeValue: isMoreTab && showErrorBadge ? errorCount.toString() : '',
+                badgeValue: isMoreTab && showErrorBadge ? errorCount.toString() : "",
               }}
             >
-              <Label selectedStyle={{ color: tabs.selectedLabelColor }}>
-                {label}
-              </Label>
+              <Label selectedStyle={{ color: tabs.selectedLabelColor }}>{label}</Label>
               <Icon
                 sf={{
                   default: tab.sfSymbol.default,

--- a/src/app/(tabs)/more/actions.tsx
+++ b/src/app/(tabs)/more/actions.tsx
@@ -1,0 +1,96 @@
+/**
+ * Actions Screen
+ *
+ * General diagnostic and administrative actions
+ */
+
+import { clearAllLocalCovers } from "@/db/helpers/localData";
+import { useFloatingPlayerPadding } from "@/hooks/useFloatingPlayerPadding";
+import { translate } from "@/i18n";
+import { clearAllCoverCache } from "@/lib/covers";
+import { useThemedStyles } from "@/lib/theme";
+import { useAuth } from "@/providers/AuthProvider";
+import { useDb } from "@/providers/DbProvider";
+import * as Clipboard from "expo-clipboard";
+import { Stack } from "expo-router";
+import { useCallback } from "react";
+import { Pressable, SectionList, Text, View } from "react-native";
+
+type Section = {
+  title: string;
+  data: ActionItem[];
+};
+
+type ActionItem = {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+export default function ActionsScreen() {
+  const { styles, isDark } = useThemedStyles();
+  const { accessToken, logout } = useAuth();
+  const { resetDatabase } = useDb();
+  const floatingPlayerPadding = useFloatingPlayerPadding();
+
+  const clearCoverCache = useCallback(async () => {
+    try {
+      await clearAllCoverCache();
+      await clearAllLocalCovers();
+      console.log("Cover cache and database imageUrls cleared successfully");
+    } catch (error) {
+      console.error("Failed to clear cover cache:", error);
+    }
+  }, []);
+
+  const sections: Section[] = [
+    {
+      title: translate("advanced.sections.actions"),
+      data: [
+        {
+          label: translate("advanced.actions.copyAccessToken"),
+          onPress: async () => {
+            if (accessToken) {
+              await Clipboard.setStringAsync(accessToken);
+            }
+          },
+          disabled: !accessToken,
+        },
+        {
+          label: translate("advanced.actions.resetApp"),
+          onPress: async () => {
+            resetDatabase();
+            await clearCoverCache();
+            await logout();
+          },
+          disabled: false,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item, index) => item.label + index}
+        renderSectionHeader={({ section: { title } }) => (
+          <View style={{ marginBottom: 12, marginTop: 20, paddingHorizontal: 16 }}>
+            <Text style={{ ...styles.text, fontWeight: "bold", fontSize: 18 }}>{title}</Text>
+          </View>
+        )}
+        renderItem={({ item }: { item: ActionItem }) => (
+          <View style={styles.listItem}>
+            <Pressable onPress={item.onPress} disabled={item.disabled}>
+              <Text style={item.disabled ? styles.text : styles.link}>{item.label}</Text>
+            </Pressable>
+          </View>
+        )}
+        contentContainerStyle={[styles.flatListContainer, floatingPlayerPadding]}
+        indicatorStyle={isDark ? "white" : "black"}
+        stickySectionHeadersEnabled={false}
+      />
+      <Stack.Screen options={{ title: translate("actions.title") }} />
+    </>
+  );
+}

--- a/src/app/(tabs)/more/library-stats.tsx
+++ b/src/app/(tabs)/more/library-stats.tsx
@@ -1,0 +1,136 @@
+/**
+ * Library Stats Screen
+ *
+ * Displays library content statistics including counts for authors, genres,
+ * languages, narrators, series, and tags
+ */
+
+import { useFloatingPlayerPadding } from "@/hooks/useFloatingPlayerPadding";
+import { translate } from "@/i18n";
+import { useThemedStyles } from "@/lib/theme";
+import { useLibrary, useStatistics } from "@/stores";
+import { Stack } from "expo-router";
+import { useCallback, useEffect } from "react";
+import { Pressable, SectionList, Text, View } from "react-native";
+
+type Section = {
+  title: string;
+  data: ActionItem[];
+};
+
+type ActionItem = {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+const disabledOnPress = () => undefined;
+
+export default function LibraryStatsScreen() {
+  const { styles, isDark } = useThemedStyles();
+  const { refresh, selectedLibrary, libraries } = useLibrary();
+  const { counts, refreshStatistics } = useStatistics();
+  const floatingPlayerPadding = useFloatingPlayerPadding();
+
+  const refreshCounts = useCallback(async () => {
+    try {
+      await refreshStatistics();
+    } catch (error) {
+      console.error("Failed to fetch counts:", error);
+    }
+  }, [refreshStatistics]);
+
+  useEffect(() => {
+    void refreshCounts();
+  }, [refreshCounts]);
+
+  const sections: Section[] = [
+    {
+      title: translate("advanced.sections.libraryStats"),
+      data: [
+        {
+          label: translate("advanced.stats.librariesFound", { count: libraries.length }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.stats.selectedLibrary", {
+            name: selectedLibrary?.name ?? translate("advanced.stats.selectedLibraryNone"),
+          }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.stats.authors", { count: counts.authors }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.stats.genres", { count: counts.genres }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.stats.languages", { count: counts.languages }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.stats.narrators", { count: counts.narrators }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.stats.series", { count: counts.series }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.stats.tags", { count: counts.tags }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+      ],
+    },
+    {
+      title: translate("advanced.sections.actions"),
+      data: [
+        {
+          label: translate("advanced.actions.refreshLibraries"),
+          onPress: refresh,
+          disabled: false,
+        },
+        {
+          label: translate("advanced.actions.refreshStats"),
+          onPress: refreshCounts,
+          disabled: false,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item, index) => item.label + index}
+        renderSectionHeader={({ section: { title } }) => (
+          <View style={{ marginBottom: 12, marginTop: 20, paddingHorizontal: 16 }}>
+            <Text style={{ ...styles.text, fontWeight: "bold", fontSize: 18 }}>{title}</Text>
+          </View>
+        )}
+        renderItem={({ item }: { item: ActionItem }) => (
+          <View style={styles.listItem}>
+            <Pressable onPress={item.onPress} disabled={item.disabled}>
+              <Text style={item.disabled ? styles.text : styles.link}>{item.label}</Text>
+            </Pressable>
+          </View>
+        )}
+        contentContainerStyle={[styles.flatListContainer, floatingPlayerPadding]}
+        indicatorStyle={isDark ? "white" : "black"}
+        stickySectionHeadersEnabled={false}
+      />
+      <Stack.Screen options={{ title: translate("libraryStats.title") }} />
+    </>
+  );
+}

--- a/src/app/(tabs)/more/settings.tsx
+++ b/src/app/(tabs)/more/settings.tsx
@@ -21,10 +21,12 @@ export default function SettingsScreen() {
     jumpForwardInterval,
     jumpBackwardInterval,
     smartRewindEnabled,
+    diagnosticsEnabled,
     isLoading,
     updateJumpForwardInterval,
     updateJumpBackwardInterval,
     updateSmartRewindEnabled,
+    updateDiagnosticsEnabled,
   } = useSettings();
   const { libraries, selectedLibrary, selectLibrary } = useLibrary();
 
@@ -69,6 +71,19 @@ export default function SettingsScreen() {
       }
     },
     [updateSmartRewindEnabled]
+  );
+
+  // Toggle diagnostics
+  const toggleDiagnostics = useCallback(
+    async (value: boolean) => {
+      try {
+        await updateDiagnosticsEnabled(value);
+      } catch (error) {
+        console.error("Failed to update diagnostics setting", error);
+        Alert.alert(translate("common.error"), translate("settings.error.saveFailed"));
+      }
+    },
+    [updateDiagnosticsEnabled]
   );
 
   if (isLoading) {
@@ -273,6 +288,50 @@ export default function SettingsScreen() {
               </Text>
             </View>
             <Toggle value={smartRewindEnabled} onValueChange={toggleSmartRewind} />
+          </View>
+        </View>
+
+        {/* Developer Section */}
+        <View style={{ padding: 16 }}>
+          <Text
+            style={{
+              fontSize: 13,
+              fontWeight: "600",
+              color: textSecondary,
+              marginBottom: 12,
+              textTransform: "uppercase",
+            }}
+          >
+            {translate("settings.sections.developer")}
+          </Text>
+
+          {/* Diagnostics Toggle */}
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "center",
+              paddingVertical: 14,
+              backgroundColor: isDark ? "#1C1C1E" : "#FFFFFF",
+              borderRadius: 10,
+            }}
+          >
+            <View style={{ flex: 1, marginRight: 12 }}>
+              <Text
+                style={{
+                  fontSize: 15,
+                  color: colors.textPrimary,
+                  fontWeight: "500",
+                  marginBottom: 4,
+                }}
+              >
+                {translate("settings.diagnostics")}
+              </Text>
+              <Text style={{ fontSize: 13, color: textSecondary, lineHeight: 18 }}>
+                {translate("settings.diagnosticsDescription")}
+              </Text>
+            </View>
+            <Toggle value={diagnosticsEnabled} onValueChange={toggleDiagnostics} />
           </View>
         </View>
       </ScrollView>

--- a/src/app/(tabs)/more/storage.tsx
+++ b/src/app/(tabs)/more/storage.tsx
@@ -1,0 +1,460 @@
+/**
+ * Storage Screen
+ *
+ * Displays storage usage statistics including metadata database, logs,
+ * cover cache, and downloaded files
+ */
+
+import { db } from "@/db/client";
+import {
+  clearAllLocalCovers,
+  getAllDownloadedAudioFiles,
+  getAllDownloadedLibraryFiles,
+  getAllLocalCovers,
+} from "@/db/helpers/localData";
+import { audioFiles } from "@/db/schema/audioFiles";
+import { libraryFiles } from "@/db/schema/libraryFiles";
+import { mediaMetadata } from "@/db/schema/mediaMetadata";
+import { useFloatingPlayerPadding } from "@/hooks/useFloatingPlayerPadding";
+import { translate } from "@/i18n";
+import { clearAllCoverCache } from "@/lib/covers";
+import { formatBytes } from "@/lib/helpers/formatters";
+import { useThemedStyles } from "@/lib/theme";
+import { type StorageEntry, useStatistics } from "@/stores";
+import { inArray } from "drizzle-orm";
+import { Directory, File, Paths } from "expo-file-system";
+import { Stack } from "expo-router";
+import { defaultDatabaseDirectory } from "expo-sqlite";
+import { useCallback, useEffect, useState } from "react";
+import { Pressable, SectionList, Text, View } from "react-native";
+
+type Section = {
+  title: string;
+  data: ActionItem[];
+};
+
+type ActionItem = {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  columns?: [string, string, string];
+  isHeader?: boolean;
+};
+
+type StorageBucketStats = {
+  count: number;
+  size: number;
+};
+
+const disabledOnPress = () => undefined;
+
+function collectFileStats(paths: string[]): StorageBucketStats {
+  return paths.reduce<StorageBucketStats>(
+    (acc, path) => {
+      if (!path) {
+        return acc;
+      }
+
+      try {
+        const file = new File(path);
+        if (!file.exists) {
+          return acc;
+        }
+
+        return {
+          count: acc.count + 1,
+          size: acc.size + (file.size ?? 0),
+        };
+      } catch (error) {
+        console.warn("[Storage] Failed to inspect file:", error);
+        return acc;
+      }
+    },
+    { count: 0, size: 0 }
+  );
+}
+
+function getSQLiteDirectory(): Directory {
+  if (defaultDatabaseDirectory) {
+    return new Directory(defaultDatabaseDirectory);
+  }
+
+  return new Directory(Paths.document, "SQLite");
+}
+
+function formatFileCount(count: number): string {
+  if (count === 1) {
+    return "1 file";
+  }
+
+  return `${count} files`;
+}
+
+function normalizeTitle(value: string | null | undefined): string {
+  if (!value) {
+    return translate("advanced.trackPlayer.unknownItem");
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return translate("advanced.trackPlayer.unknownItem");
+  }
+
+  return trimmed;
+}
+
+export default function StorageScreen() {
+  const { styles, isDark } = useThemedStyles();
+  const { refreshStorageStats: updateStorageStatsInStore } = useStatistics();
+  const floatingPlayerPadding = useFloatingPlayerPadding();
+
+  const [storageEntries, setStorageEntries] = useState<StorageEntry[]>([]);
+
+  const refreshStorageStats = useCallback(async () => {
+    try {
+      const [coverRows, audioRows, libraryRows] = await Promise.all([
+        getAllLocalCovers(),
+        getAllDownloadedAudioFiles(),
+        getAllDownloadedLibraryFiles(),
+      ]);
+
+      const sqliteDirectory = getSQLiteDirectory();
+      const metadataDbFile = new File(sqliteDirectory, "abs2.sqlite");
+      const logDbFile = new File(sqliteDirectory, "logs.sqlite");
+      const covers = collectFileStats(coverRows.map((row) => row.localCoverUrl));
+
+      const metadataStats: StorageBucketStats = metadataDbFile.exists
+        ? { count: 1, size: metadataDbFile.size ?? 0 }
+        : { count: 0, size: 0 };
+
+      const logStats: StorageBucketStats = logDbFile.exists
+        ? { count: 1, size: logDbFile.size ?? 0 }
+        : { count: 0, size: 0 };
+
+      const downloadsByLibraryItem = new Map<string, { title: string; paths: string[] }>();
+
+      const audioFileIds = audioRows.map((row) => row.audioFileId).filter(Boolean);
+      const libraryFileIds = libraryRows.map((row) => row.libraryFileId).filter(Boolean);
+
+      const audioFileInfos =
+        audioFileIds.length > 0
+          ? await db
+              .select({
+                id: audioFiles.id,
+                mediaId: audioFiles.mediaId,
+              })
+              .from(audioFiles)
+              .where(inArray(audioFiles.id, audioFileIds))
+          : [];
+
+      const mediaIds = Array.from(
+        new Set(
+          audioFileInfos
+            .map((info) => info.mediaId)
+            .filter((id): id is string => typeof id === "string" && id.length > 0)
+        )
+      );
+
+      const metadataRows =
+        mediaIds.length > 0
+          ? await db
+              .select({
+                id: mediaMetadata.id,
+                libraryItemId: mediaMetadata.libraryItemId,
+                title: mediaMetadata.title,
+              })
+              .from(mediaMetadata)
+              .where(inArray(mediaMetadata.id, mediaIds))
+          : [];
+
+      const metadataByMediaId = new Map<string, { libraryItemId: string; title: string | null }>();
+      const libraryTitleById = new Map<string, string>();
+
+      const ensureLibraryItemTitle = (
+        libraryItemId: string,
+        fallbackTitle?: string | null
+      ): string => {
+        const existing = libraryTitleById.get(libraryItemId);
+        if (existing) {
+          return existing;
+        }
+        const normalized = normalizeTitle(fallbackTitle);
+        libraryTitleById.set(libraryItemId, normalized);
+        return normalized;
+      };
+
+      metadataRows.forEach((row) => {
+        metadataByMediaId.set(row.id, { libraryItemId: row.libraryItemId, title: row.title });
+        ensureLibraryItemTitle(row.libraryItemId, row.title);
+      });
+
+      const libraryFileInfos =
+        libraryFileIds.length > 0
+          ? await db
+              .select({
+                id: libraryFiles.id,
+                libraryItemId: libraryFiles.libraryItemId,
+              })
+              .from(libraryFiles)
+              .where(inArray(libraryFiles.id, libraryFileIds))
+          : [];
+
+      const missingLibraryItemIds = Array.from(
+        new Set(
+          libraryFileInfos
+            .map((info) => info.libraryItemId)
+            .filter(
+              (libraryItemId): libraryItemId is string =>
+                typeof libraryItemId === "string" &&
+                libraryItemId.length > 0 &&
+                !libraryTitleById.has(libraryItemId)
+            )
+        )
+      );
+
+      if (missingLibraryItemIds.length > 0) {
+        const additionalMetadataRows = await db
+          .select({
+            libraryItemId: mediaMetadata.libraryItemId,
+            title: mediaMetadata.title,
+          })
+          .from(mediaMetadata)
+          .where(inArray(mediaMetadata.libraryItemId, missingLibraryItemIds));
+
+        additionalMetadataRows.forEach((row) => {
+          ensureLibraryItemTitle(row.libraryItemId, row.title);
+        });
+      }
+
+      const audioFileInfoMap = new Map(audioFileInfos.map((info) => [info.id, info.mediaId]));
+      const libraryFileInfoMap = new Map(
+        libraryFileInfos.map((info) => [info.id, info.libraryItemId])
+      );
+
+      const addDownloadToGroup = (libraryItemId: string, title: string, path: string) => {
+        if (!libraryItemId || !path) {
+          return;
+        }
+
+        const existing = downloadsByLibraryItem.get(libraryItemId);
+        if (existing) {
+          existing.paths.push(path);
+        } else {
+          downloadsByLibraryItem.set(libraryItemId, {
+            title,
+            paths: [path],
+          });
+        }
+      };
+
+      audioRows.forEach((row) => {
+        const mediaId = audioFileInfoMap.get(row.audioFileId);
+        if (!mediaId) {
+          return;
+        }
+
+        const metadata = metadataByMediaId.get(mediaId);
+        if (!metadata) {
+          return;
+        }
+
+        const title = ensureLibraryItemTitle(metadata.libraryItemId, metadata.title);
+        addDownloadToGroup(metadata.libraryItemId, title, row.downloadPath);
+      });
+
+      libraryRows.forEach((row) => {
+        const libraryItemId = libraryFileInfoMap.get(row.libraryFileId);
+        if (!libraryItemId) {
+          return;
+        }
+
+        const title = ensureLibraryItemTitle(libraryItemId);
+        addDownloadToGroup(libraryItemId, title, row.downloadPath);
+      });
+
+      const entries: StorageEntry[] = [
+        {
+          id: "metadata-db",
+          title: translate("advanced.storage.metadataDb"),
+          count: metadataStats.count,
+          size: metadataStats.size,
+        },
+        {
+          id: "log-db",
+          title: translate("advanced.storage.logDb"),
+          count: logStats.count,
+          size: logStats.size,
+        },
+        {
+          id: "cover-cache",
+          title: translate("advanced.storage.coverCache"),
+          count: covers.count,
+          size: covers.size,
+        },
+      ];
+
+      const downloadEntries = Array.from(downloadsByLibraryItem.entries())
+        .map(([libraryItemId, group]) => {
+          const stats = collectFileStats(group.paths);
+          return {
+            id: `downloads-${libraryItemId}`,
+            title: group.title,
+            count: stats.count,
+            size: stats.size,
+          };
+        })
+        .filter((entry) => entry.count > 0)
+        .sort((a, b) => a.title.localeCompare(b.title));
+
+      // Calculate total storage
+      const totalSize =
+        entries.reduce((sum, entry) => sum + entry.size, 0) +
+        downloadEntries.reduce((sum, entry) => sum + entry.size, 0);
+      const totalCount =
+        entries.reduce((sum, entry) => sum + entry.count, 0) +
+        downloadEntries.reduce((sum, entry) => sum + entry.count, 0);
+
+      // Add total entry at the beginning
+      const totalEntry: StorageEntry = {
+        id: "total",
+        title: translate("advanced.storage.totalUsed"),
+        count: totalCount,
+        size: totalSize,
+      };
+
+      entries.unshift(totalEntry);
+
+      const allEntries = [...entries, ...downloadEntries];
+      setStorageEntries(allEntries);
+
+      // Update storage stats in the store
+      updateStorageStatsInStore(allEntries);
+    } catch (error) {
+      console.error("Failed to refresh storage stats:", error);
+      setStorageEntries([]);
+    }
+  }, [updateStorageStatsInStore]);
+
+  const clearCoverCache = useCallback(async () => {
+    try {
+      await clearAllCoverCache();
+      await clearAllLocalCovers();
+      console.log("Cover cache and database imageUrls cleared successfully");
+    } catch (error) {
+      console.error("Failed to clear cover cache:", error);
+    }
+    await refreshStorageStats();
+  }, [refreshStorageStats]);
+
+  useEffect(() => {
+    void refreshStorageStats();
+  }, [refreshStorageStats]);
+
+  const sections: Section[] = [
+    {
+      title: translate("advanced.sections.storage"),
+      data: [
+        {
+          label: "storage-header",
+          onPress: disabledOnPress,
+          disabled: true,
+          columns: [
+            translate("advanced.storage.tableHeaders.item"),
+            translate("advanced.storage.tableHeaders.files"),
+            translate("advanced.storage.tableHeaders.size"),
+          ],
+          isHeader: true,
+        },
+        ...storageEntries.map((entry) => ({
+          label: entry.id,
+          onPress: disabledOnPress,
+          disabled: true,
+          columns: [entry.title, formatFileCount(entry.count), formatBytes(entry.size)] as [
+            string,
+            string,
+            string,
+          ],
+        })),
+      ],
+    },
+    {
+      title: translate("advanced.sections.actions"),
+      data: [
+        {
+          label: translate("advanced.actions.clearCoverCache"),
+          onPress: clearCoverCache,
+          disabled: false,
+        },
+        {
+          label: translate("advanced.actions.refreshStats"),
+          onPress: refreshStorageStats,
+          disabled: false,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item, index) => item.label + index}
+        renderSectionHeader={({ section: { title } }) => (
+          <View style={{ marginBottom: 12, marginTop: 20, paddingHorizontal: 16 }}>
+            <Text style={{ ...styles.text, fontWeight: "bold", fontSize: 18 }}>{title}</Text>
+          </View>
+        )}
+        renderItem={({ item }: { item: ActionItem }) => {
+          if (item.columns) {
+            return (
+              <View
+                style={[
+                  styles.listItem,
+                  {
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 12,
+                  },
+                ]}
+              >
+                <Text style={[styles.text, { flex: 1 }, item.isHeader && { fontWeight: "600" }]}>
+                  {item.columns[0]}
+                </Text>
+                <Text
+                  style={[
+                    styles.text,
+                    { width: 90, textAlign: "right" },
+                    item.isHeader && { fontWeight: "600" },
+                  ]}
+                >
+                  {item.columns[1]}
+                </Text>
+                <Text
+                  style={[
+                    styles.text,
+                    { width: 110, textAlign: "right" },
+                    item.isHeader && { fontWeight: "600" },
+                  ]}
+                >
+                  {item.columns[2]}
+                </Text>
+              </View>
+            );
+          }
+
+          return (
+            <View style={styles.listItem}>
+              <Pressable onPress={item.onPress} disabled={item.disabled}>
+                <Text style={item.disabled ? styles.text : styles.link}>{item.label}</Text>
+              </Pressable>
+            </View>
+          );
+        }}
+        contentContainerStyle={[styles.flatListContainer, floatingPlayerPadding]}
+        indicatorStyle={isDark ? "white" : "black"}
+        stickySectionHeadersEnabled={false}
+      />
+      <Stack.Screen options={{ title: translate("storage.title") }} />
+    </>
+  );
+}

--- a/src/app/(tabs)/more/track-player.tsx
+++ b/src/app/(tabs)/more/track-player.tsx
@@ -1,0 +1,231 @@
+/**
+ * Track Player Screen
+ *
+ * Displays track player state information for debugging
+ */
+
+import { useFloatingPlayerPadding } from "@/hooks/useFloatingPlayerPadding";
+import { translate } from "@/i18n";
+import { useThemedStyles } from "@/lib/theme";
+import { Stack } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+import { Pressable, SectionList, Text, View } from "react-native";
+import TrackPlayer, { State, Track } from "react-native-track-player";
+
+type Section = {
+  title: string;
+  data: ActionItem[];
+};
+
+type ActionItem = {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+const disabledOnPress = () => undefined;
+
+function getStateLabel(state: State): string {
+  switch (state) {
+    case State.None:
+      return translate("advanced.trackPlayer.states.none");
+    case State.Ready:
+      return translate("advanced.trackPlayer.states.ready");
+    case State.Playing:
+      return translate("advanced.trackPlayer.states.playing");
+    case State.Paused:
+      return translate("advanced.trackPlayer.states.paused");
+    case State.Stopped:
+      return translate("advanced.trackPlayer.states.stopped");
+    case State.Buffering:
+      return translate("advanced.trackPlayer.states.buffering");
+    case State.Connecting:
+      return translate("advanced.trackPlayer.states.connecting");
+    case State.Error:
+      return translate("advanced.trackPlayer.states.error");
+    default:
+      return translate("advanced.trackPlayer.states.unknown");
+  }
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+export default function TrackPlayerScreen() {
+  const { styles, isDark } = useThemedStyles();
+  const floatingPlayerPadding = useFloatingPlayerPadding();
+
+  const [trackPlayerState, setTrackPlayerState] = useState<{
+    state: string;
+    queueLength: number;
+    currentTrackIndex: number | null;
+    currentTrack: Track | null;
+    position: number;
+    duration: number;
+    buffered: number;
+    rate: number;
+    volume: number;
+  }>({
+    state: "Unknown",
+    queueLength: 0,
+    currentTrackIndex: null,
+    currentTrack: null,
+    position: 0,
+    duration: 0,
+    buffered: 0,
+    rate: 1.0,
+    volume: 1.0,
+  });
+
+  const refreshTrackPlayerState = useCallback(async () => {
+    try {
+      const [state, queue, progress, rate, volume, activeTrackIndex] = await Promise.all([
+        TrackPlayer.getPlaybackState(),
+        TrackPlayer.getQueue(),
+        TrackPlayer.getProgress(),
+        TrackPlayer.getRate(),
+        TrackPlayer.getVolume(),
+        TrackPlayer.getActiveTrackIndex(),
+      ]);
+
+      const currentTrack =
+        activeTrackIndex !== undefined && activeTrackIndex >= 0 ? queue[activeTrackIndex] : null;
+
+      setTrackPlayerState({
+        state: getStateLabel(state.state),
+        queueLength: queue.length,
+        currentTrackIndex: activeTrackIndex ?? null,
+        currentTrack: currentTrack ?? null,
+        position: progress.position,
+        duration: progress.duration,
+        buffered: progress.buffered,
+        rate,
+        volume,
+      });
+    } catch (error) {
+      console.error("Failed to refresh TrackPlayer state:", error);
+      setTrackPlayerState({
+        state: "Error",
+        queueLength: 0,
+        currentTrackIndex: null,
+        currentTrack: null,
+        position: 0,
+        duration: 0,
+        buffered: 0,
+        rate: 1.0,
+        volume: 1.0,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshTrackPlayerState();
+  }, [refreshTrackPlayerState]);
+
+  const hasTrack = trackPlayerState.currentTrack !== null;
+
+  const sections: Section[] = [
+    {
+      title: translate("advanced.sections.trackPlayer"),
+      data: [
+        {
+          label: translate("advanced.trackPlayer.state", { state: trackPlayerState.state }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.trackPlayer.queueLength", {
+            length: trackPlayerState.queueLength,
+          }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label:
+            translate("advanced.trackPlayer.currentTrack") +
+            (trackPlayerState.currentTrackIndex !== null
+              ? translate("advanced.trackPlayer.trackIndex", {
+                  index: trackPlayerState.currentTrackIndex,
+                })
+              : translate("advanced.trackPlayer.trackNone")),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label:
+            translate("advanced.trackPlayer.track") +
+            (trackPlayerState.currentTrack?.title ?? translate("advanced.trackPlayer.trackNone")) +
+            (hasTrack
+              ? ` (${trackPlayerState.currentTrack?.id ?? translate("advanced.trackPlayer.trackNone")})`
+              : ""),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label:
+            translate("advanced.trackPlayer.position") +
+            `${formatDuration(trackPlayerState.position)} / ${formatDuration(trackPlayerState.duration)} (${formatDuration(trackPlayerState.buffered)}${translate("advanced.trackPlayer.buffered")})`,
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.trackPlayer.playbackRate", {
+            rate: trackPlayerState.rate.toFixed(2),
+          }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+        {
+          label: translate("advanced.trackPlayer.volume", {
+            volume: (trackPlayerState.volume * 100).toFixed(0),
+          }),
+          onPress: disabledOnPress,
+          disabled: true,
+        },
+      ],
+    },
+    {
+      title: translate("advanced.sections.actions"),
+      data: [
+        {
+          label: translate("advanced.actions.refreshStats"),
+          onPress: refreshTrackPlayerState,
+          disabled: false,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item, index) => item.label + index}
+        renderSectionHeader={({ section: { title } }) => (
+          <View style={{ marginBottom: 12, marginTop: 20, paddingHorizontal: 16 }}>
+            <Text style={{ ...styles.text, fontWeight: "bold", fontSize: 18 }}>{title}</Text>
+          </View>
+        )}
+        renderItem={({ item }: { item: ActionItem }) => (
+          <View style={styles.listItem}>
+            <Pressable onPress={item.onPress} disabled={item.disabled}>
+              <Text style={item.disabled ? styles.text : styles.link}>{item.label}</Text>
+            </Pressable>
+          </View>
+        )}
+        contentContainerStyle={[styles.flatListContainer, floatingPlayerPadding]}
+        indicatorStyle={isDark ? "white" : "black"}
+        stickySectionHeadersEnabled={false}
+      />
+      <Stack.Screen options={{ title: translate("trackPlayer.title") }} />
+    </>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -142,7 +142,12 @@ export const en = {
   "more.aboutMe": "About Me",
   "more.settings": "Settings",
   "more.advanced": "Advanced",
+  "more.libraryStats": "Library Stats",
+  "more.storage": "Storage",
+  "more.trackPlayer": "Track Player",
   "more.logs": "Logs",
+  "more.loggerSettings": "Logger Settings",
+  "more.actions": "Actions",
   "more.logOut": "Log out",
   "more.version": "Version {version}",
   "more.logoutConfirm.title": "Log out",
@@ -155,12 +160,16 @@ export const en = {
   "settings.sections.librarySelection": "Library Selection",
   "settings.sections.playbackControls": "Playback Controls",
   "settings.sections.advanced": "Advanced",
+  "settings.sections.developer": "Developer",
   "settings.currentLibrary": "Current Library",
   "settings.jumpForwardInterval": "Jump Forward Interval",
   "settings.jumpBackwardInterval": "Jump Backward Interval",
   "settings.smartRewind": "Smart Rewind on Resume",
   "settings.smartRewindDescription":
     "Automatically rewind a few seconds when resuming playback after a pause. The rewind time increases based on how long playback was paused (3s to 30s).",
+  "settings.diagnostics": "Enable Diagnostics",
+  "settings.diagnosticsDescription":
+    "Show diagnostic and debugging screens in the More tab. Includes logs, storage info, and track player state.",
   "settings.autoReconnect": "Auto-reconnect Background Service",
   "settings.autoReconnectDescription":
     "Automatically reconnect the audio player background service when the app returns from background or after context recreation. Disable if experiencing issues with playback.",
@@ -245,6 +254,12 @@ export const en = {
   "advanced.sections.storage": "Storage",
   "advanced.sections.trackPlayer": "Track Player",
   "advanced.sections.actions": "Actions",
+
+  // Diagnostic Screen Titles
+  "libraryStats.title": "Library Stats",
+  "storage.title": "Storage",
+  "trackPlayer.title": "Track Player",
+  "actions.title": "Actions",
   "advanced.stats.librariesFound": "Libraries found: {count}",
   "advanced.stats.selectedLibrary": "Selected library: {name}",
   "advanced.stats.selectedLibraryNone": "None",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -144,7 +144,12 @@ export const es = {
   "more.aboutMe": "Acerca de mí",
   "more.settings": "Configuración",
   "more.advanced": "Avanzado",
+  "more.libraryStats": "Estadísticas de biblioteca",
+  "more.storage": "Almacenamiento",
+  "more.trackPlayer": "Reproductor de pistas",
   "more.logs": "Registros",
+  "more.loggerSettings": "Configuración de registros",
+  "more.actions": "Acciones",
   "more.logOut": "Cerrar sesión",
   "more.version": "Versión {version}",
   "more.logoutConfirm.title": "Cerrar sesión",
@@ -157,12 +162,16 @@ export const es = {
   "settings.sections.librarySelection": "Selección de biblioteca",
   "settings.sections.playbackControls": "Controles de reproducción",
   "settings.sections.advanced": "Avanzado",
+  "settings.sections.developer": "Desarrollador",
   "settings.currentLibrary": "Biblioteca actual",
   "settings.jumpForwardInterval": "Intervalo de avance rápido",
   "settings.jumpBackwardInterval": "Intervalo de retroceso",
   "settings.smartRewind": "Rebobinado inteligente al reanudar",
   "settings.smartRewindDescription":
     "Retrocede automáticamente unos segundos al reanudar la reproducción después de una pausa. El tiempo de retroceso aumenta según el tiempo que estuvo pausada la reproducción (3s a 30s).",
+  "settings.diagnostics": "Habilitar diagnósticos",
+  "settings.diagnosticsDescription":
+    "Mostrar pantallas de diagnóstico y depuración en la pestaña Más. Incluye registros, información de almacenamiento y estado del reproductor de pistas.",
   "settings.autoReconnect": "Reconexión automática del servicio en segundo plano",
   "settings.autoReconnectDescription":
     "Reconectar automáticamente el servicio del reproductor de audio en segundo plano cuando la aplicación vuelve del fondo o después de la recreación del contexto. Desactiva si experimentas problemas con la reproducción.",
@@ -250,6 +259,12 @@ export const es = {
   "advanced.sections.storage": "Almacenamiento",
   "advanced.sections.trackPlayer": "Reproductor de pistas",
   "advanced.sections.actions": "Acciones",
+
+  // Diagnostic Screen Titles
+  "libraryStats.title": "Estadísticas de biblioteca",
+  "storage.title": "Almacenamiento",
+  "trackPlayer.title": "Reproductor de pistas",
+  "actions.title": "Acciones",
   "advanced.stats.librariesFound": "Bibliotecas encontradas: {count}",
   "advanced.stats.selectedLibrary": "Biblioteca seleccionada: {name}",
   "advanced.stats.selectedLibraryNone": "Ninguna",

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -12,6 +12,7 @@ const SETTINGS_KEYS = {
   enableSmartRewind: "@app/enableSmartRewind",
   enablePeriodicNowPlayingUpdates: "@app/enablePeriodicNowPlayingUpdates",
   homeLayout: "@app/homeLayout",
+  enableDiagnostics: "@app/enableDiagnostics",
 } as const;
 
 // Default values
@@ -20,6 +21,7 @@ const DEFAULT_JUMP_BACKWARD_INTERVAL = 15;
 const DEFAULT_SMART_REWIND_ENABLED = true;
 const DEFAULT_PERIODIC_NOW_PLAYING_UPDATES_ENABLED = true;
 const DEFAULT_HOME_LAYOUT = "list" as const;
+const DEFAULT_DIAGNOSTICS_ENABLED = false;
 
 /**
  * Get jump forward interval in seconds
@@ -154,6 +156,32 @@ export async function setHomeLayout(layout: "list" | "cover"): Promise<void> {
     await AsyncStorage.setItem(SETTINGS_KEYS.homeLayout, layout);
   } catch (error) {
     console.error("[AppSettings] Failed to save home layout setting:", error);
+    throw error;
+  }
+}
+
+/**
+ * Get whether diagnostics mode is enabled
+ * Default: false (disabled)
+ */
+export async function getDiagnosticsEnabled(): Promise<boolean> {
+  try {
+    const value = await AsyncStorage.getItem(SETTINGS_KEYS.enableDiagnostics);
+    return value === null ? DEFAULT_DIAGNOSTICS_ENABLED : value === "true";
+  } catch (error) {
+    console.error("[AppSettings] Failed to get diagnostics setting:", error);
+    return DEFAULT_DIAGNOSTICS_ENABLED;
+  }
+}
+
+/**
+ * Set whether diagnostics mode is enabled
+ */
+export async function setDiagnosticsEnabled(enabled: boolean): Promise<void> {
+  try {
+    await AsyncStorage.setItem(SETTINGS_KEYS.enableDiagnostics, enabled ? "true" : "false");
+  } catch (error) {
+    console.error("[AppSettings] Failed to save diagnostics setting:", error);
     throw error;
   }
 }

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -5,7 +5,7 @@
  * and promote consistency across the application.
  */
 
-import { StyleSheet } from 'react-native';
+import { StyleSheet } from "react-native";
 
 /**
  * Common spacing values
@@ -30,7 +30,7 @@ export const floatingPlayer = {
   /** Bottom offset above tab bar */
   bottomOffset: 100,
   /** Padding to add to scrollable lists when player is visible */
-  listPadding: 76,
+  listPadding: 84,
 } as const;
 
 /**
@@ -40,45 +40,45 @@ export const floatingPlayer = {
 export const commonStyles = StyleSheet.create({
   // Flex layouts
   flexRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
   },
   flexRowBetween: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   flexRowCenter: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
   },
   flexColumn: {
-    flexDirection: 'column',
+    flexDirection: "column",
   },
   flex1: {
     flex: 1,
   },
   flexWrap: {
-    flexWrap: 'wrap',
+    flexWrap: "wrap",
   },
 
   // Alignment
   centered: {
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
   },
   alignCenter: {
-    alignItems: 'center',
+    alignItems: "center",
   },
   justifyCenter: {
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   alignStart: {
-    alignItems: 'flex-start',
+    alignItems: "flex-start",
   },
   alignEnd: {
-    alignItems: 'flex-end',
+    alignItems: "flex-end",
   },
 
   // Common spacing
@@ -119,13 +119,13 @@ export const commonStyles = StyleSheet.create({
 
   // Typography helpers
   textCenter: {
-    textAlign: 'center',
+    textAlign: "center",
   },
   textBold: {
-    fontWeight: '600',
+    fontWeight: "600",
   },
   textSemiBold: {
-    fontWeight: '500',
+    fontWeight: "500",
   },
 });
 
@@ -146,21 +146,21 @@ export const borderRadius = {
  */
 export const shadows = {
   small: {
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,
     shadowRadius: 2,
     elevation: 2,
   },
   medium: {
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.15,
     shadowRadius: 4,
     elevation: 4,
   },
   large: {
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.2,
     shadowRadius: 8,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -797,6 +797,7 @@ export function useSettings() {
   const jumpBackwardInterval = useAppStore((state) => state.settings.jumpBackwardInterval);
   const smartRewindEnabled = useAppStore((state) => state.settings.smartRewindEnabled);
   const homeLayout = useAppStore((state) => state.settings.homeLayout);
+  const diagnosticsEnabled = useAppStore((state) => state.settings.diagnosticsEnabled);
   const initialized = useAppStore((state) => state.settings.initialized);
   const isLoading = useAppStore((state) => state.settings.isLoading);
 
@@ -806,6 +807,7 @@ export function useSettings() {
   const updateJumpBackwardInterval = useAppStore((state) => state.updateJumpBackwardInterval);
   const updateSmartRewindEnabled = useAppStore((state) => state.updateSmartRewindEnabled);
   const updateHomeLayout = useAppStore((state) => state.updateHomeLayout);
+  const updateDiagnosticsEnabled = useAppStore((state) => state.updateDiagnosticsEnabled);
   const resetSettings = useAppStore((state) => state.resetSettings);
 
   return React.useMemo(
@@ -814,6 +816,7 @@ export function useSettings() {
       jumpBackwardInterval,
       smartRewindEnabled,
       homeLayout,
+      diagnosticsEnabled,
       initialized,
       isLoading,
       initializeSettings,
@@ -821,6 +824,7 @@ export function useSettings() {
       updateJumpBackwardInterval,
       updateSmartRewindEnabled,
       updateHomeLayout,
+      updateDiagnosticsEnabled,
       resetSettings,
     }),
     [
@@ -828,6 +832,7 @@ export function useSettings() {
       jumpBackwardInterval,
       smartRewindEnabled,
       homeLayout,
+      diagnosticsEnabled,
       initialized,
       isLoading,
       initializeSettings,
@@ -835,6 +840,7 @@ export function useSettings() {
       updateJumpBackwardInterval,
       updateSmartRewindEnabled,
       updateHomeLayout,
+      updateDiagnosticsEnabled,
       resetSettings,
     ]
   );


### PR DESCRIPTION
Introduces a diagnostics/developer mode toggle in settings, enabling access to new diagnostic screens in the More tab: Library Stats, Storage, Track Player, Actions, and Logger Settings. Updates settings state, i18n translations, and related logic to support diagnostics mode, including tests and persistent storage.

Disable claude code review for now, seems to be eating up a lot of quota