### PR TITLE
Extract updateNowPlayingMetadata to pure library function

### DIFF
--- a/docs/investigation/current-track-ownership.md
+++ b/docs/investigation/current-track-ownership.md
@@ -1,0 +1,64 @@
+# currentTrack Ownership: PSC vs Store
+
+## Summary
+
+`currentTrack` (the `PlayerTrack` object) currently has **two partially-overlapping sources of truth**, which creates timing windows and necessitates workarounds in the coordinator.
+
+## Current State
+
+| Source                            | How it gets set                                                        | When                            |
+| --------------------------------- | ---------------------------------------------------------------------- | ------------------------------- |
+| `store.player.currentTrack`       | `store._setCurrentTrack(track)` called directly by collaborators       | Immediately when track is built |
+| `this.context.currentTrack` (PSC) | `updateContextFromEvent` on `RESTORE_STATE` and `NATIVE_TRACK_CHANGED` | After native callback fires     |
+
+### Who writes to the store directly (bypassing PSC)
+
+- `TrackLoadingCollaborator` — builds track from queue + DB, writes to store
+- `ProgressRestoreCollaborator` — restores track from DB session, writes to store
+- `BackgroundReconnectCollaborator` — updates cover URI on reconnect, writes to store
+- `PlayerStateCoordinator` — writes to store **only on STOP** (to null it)
+
+### The timing gap
+
+`TrackLoadingCollaborator` sets `store.player.currentTrack` immediately when it builds the track. `NATIVE_TRACK_CHANGED` fires later (after the native TrackPlayer callback), which is when `this.context.currentTrack` gets set. During that window, the store has the track but the PSC context does not.
+
+This is why `syncPositionToStore` reads `store.player.currentTrack` rather than `this.context.currentTrack` when calling `updateNowPlayingMetadata` — the context's copy is not reliably current at chapter-boundary detection time.
+
+The documented exception lives in `syncStateToStore`:
+
+> "currentTrack exception: Only synced on STOP (to clear). PlayerService retains responsibility for building and setting PlayerTrack objects — coordinator cannot build PlayerTrack."
+
+## Why the PSC Can't Own It Today
+
+The PSC is a pure event processor with no database access. `PlayerTrack` is built by collaborators that do DB lookups (`TrackLoadingCollaborator`, `ProgressRestoreCollaborator`). The PSC cannot construct the object itself.
+
+This is a **construction** concern, not an **ownership** concern — they are separable.
+
+## Path to PSC Ownership
+
+Moving `currentTrack` to be PSC-owned (with the store as a read-only reflection) would eliminate the dual source of truth:
+
+1. Collaborators dispatch a new event (e.g., `TRACK_BUILT`) carrying the `PlayerTrack` instead of calling `store._setCurrentTrack()` directly
+2. `updateContextFromEvent` handles `TRACK_BUILT`, setting `this.context.currentTrack`
+3. `syncStateToStore` syncs `currentTrack` to the store on every structural event (not just STOP)
+4. `PlayerBackgroundService` continues reading from the store — no change needed
+
+**Benefits:**
+
+- Single source of truth in PSC context (consistent with how `position`, `isPlaying`, `sessionId`, etc. are all managed)
+- `syncPositionToStore` and `syncStateToStore` can use `this.context.currentTrack` directly without the one-tick lag risk
+- Eliminates the timing window between collaborator write and `NATIVE_TRACK_CHANGED`
+
+**Risks to audit before doing this:**
+
+- Cold-start / `RESTORE_STATE` path: the store is hydrated from AsyncStorage before the PSC processes any events — need to ensure `RESTORE_STATE` still sets context correctly
+- Background mode: `NATIVE_TRACK_CHANGED` may behave differently in headless Android BGS context
+- Queue reloads (`RELOAD_QUEUE` / `QUEUE_RELOADED`): verify the track object is still valid post-reload
+- All callers of `store._setCurrentTrack()` must be converted to the new event
+
+## Related
+
+- `src/services/coordinator/PlayerStateCoordinator.ts` — `syncStateToStore`, `syncPositionToStore`, `updateContextFromEvent`
+- `src/services/player/TrackLoadingCollaborator.ts`
+- `src/services/player/ProgressRestoreCollaborator.ts`
+- `src/lib/nowPlayingMetadata.ts` — created in `fix-lockscreen-time-sync` branch as a workaround for the position lag; reads track from store rather than PSC context for the same reason

--- a/src/__tests__/mocks/stores.ts
+++ b/src/__tests__/mocks/stores.ts
@@ -49,7 +49,6 @@ export interface MockPlayerSlice {
   setSleepTimerChapter: jest.Mock;
   cancelSleepTimer: jest.Mock;
   getSleepTimerRemaining: jest.Mock;
-  updateNowPlayingMetadata: jest.Mock;
   restorePersistedState: jest.Mock;
   initializePlayerSlice: jest.Mock;
 }
@@ -111,7 +110,6 @@ export function createMockPlayerSlice(options: MockPlayerSliceOptions = {}): Moc
     setSleepTimerChapter: jest.fn(),
     cancelSleepTimer: jest.fn(),
     getSleepTimerRemaining: jest.fn(),
-    updateNowPlayingMetadata: jest.fn(),
     restorePersistedState: jest.fn(),
     initializePlayerSlice: jest.fn(),
     ...methods,

--- a/src/lib/__tests__/nowPlayingMetadata.test.ts
+++ b/src/lib/__tests__/nowPlayingMetadata.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for updateNowPlayingMetadata lib function
+ */
+
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import TrackPlayer from "react-native-track-player";
+import { updateNowPlayingMetadata } from "../nowPlayingMetadata";
+import type { PlayerTrack } from "@/types/player";
+
+jest.mock("react-native-track-player", () => ({
+  getActiveTrackIndex: jest.fn(),
+  updateMetadataForTrack: jest.fn(),
+}));
+
+jest.mock("@/lib/trackPlayerConfig", () => ({
+  configureTrackPlayer: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { forTag: () => ({ debug: jest.fn(), warn: jest.fn(), error: jest.fn() }) },
+}));
+
+const mockedTrackPlayer = TrackPlayer as jest.Mocked<typeof TrackPlayer>;
+const { configureTrackPlayer } = require("@/lib/trackPlayerConfig");
+
+const mockTrack: PlayerTrack = {
+  libraryItemId: "item-1",
+  mediaId: "media-1",
+  title: "Test Book",
+  author: "Test Author",
+  coverUri: "file:///test-cover.jpg",
+  duration: 3600,
+  isDownloaded: true,
+  chapters: [
+    { id: "ch-1", chapterId: 1, title: "Chapter 1", start: 0, end: 1800, mediaId: "media-1" },
+    { id: "ch-2", chapterId: 2, title: "Chapter 2", start: 1800, end: 3600, mediaId: "media-1" },
+  ],
+  audioFiles: [],
+};
+
+describe("updateNowPlayingMetadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedTrackPlayer.getActiveTrackIndex.mockResolvedValue(0);
+    (mockedTrackPlayer.updateMetadataForTrack as jest.Mock).mockResolvedValue(undefined);
+    configureTrackPlayer.mockResolvedValue(undefined);
+  });
+
+  it("updates TrackPlayer with chapter-relative elapsed time", async () => {
+    await updateNowPlayingMetadata(mockTrack, 100);
+
+    expect(mockedTrackPlayer.updateMetadataForTrack).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        title: "Chapter 1",
+        artist: "Test Author",
+        album: "Test Book",
+        artwork: "file:///test-cover.jpg",
+        duration: 1800,
+        elapsedTime: 100,
+      })
+    );
+  });
+
+  it("resets elapsed time to 0 at the start of chapter 2", async () => {
+    await updateNowPlayingMetadata(mockTrack, 1800);
+
+    expect(mockedTrackPlayer.updateMetadataForTrack).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        title: "Chapter 2",
+        duration: 1800,
+        elapsedTime: 0,
+      })
+    );
+  });
+
+  it("clamps elapsed time to chapterDuration when position overshoots", async () => {
+    // Position slightly past chapter 1 end (handled by clamp before chapter change detected)
+    await updateNowPlayingMetadata(mockTrack, 1799.9);
+
+    const call = (mockedTrackPlayer.updateMetadataForTrack as jest.Mock).mock.calls[0][1] as any;
+    expect(call.elapsedTime).toBeLessThanOrEqual(call.duration);
+  });
+
+  it("skips when track has no chapters", async () => {
+    const trackNoChapters = { ...mockTrack, chapters: [] };
+    await updateNowPlayingMetadata(trackNoChapters, 100);
+
+    expect(mockedTrackPlayer.updateMetadataForTrack).not.toHaveBeenCalled();
+  });
+
+  it("skips when no active track index", async () => {
+    mockedTrackPlayer.getActiveTrackIndex.mockResolvedValue(null as any);
+    await updateNowPlayingMetadata(mockTrack, 100);
+
+    expect(mockedTrackPlayer.updateMetadataForTrack).not.toHaveBeenCalled();
+  });
+
+  it("calls configureTrackPlayer after metadata update", async () => {
+    await updateNowPlayingMetadata(mockTrack, 100);
+
+    expect(configureTrackPlayer).toHaveBeenCalled();
+  });
+});

--- a/src/lib/nowPlayingMetadata.ts
+++ b/src/lib/nowPlayingMetadata.ts
@@ -1,0 +1,81 @@
+/**
+ * Now Playing Metadata
+ *
+ * Pure library function for updating the iOS/Android lock screen and now-playing
+ * center with chapter-relative metadata.
+ *
+ * Accepts explicit parameters so callers (the coordinator, service collaborators)
+ * can use their own authoritative data rather than reading from the Zustand store.
+ * This avoids a one-tick lag and removes a React-state dependency from what is
+ * purely a native API call.
+ *
+ * Algorithm: the track's absolute playback position is converted to a
+ * chapter-relative elapsed time so the lock screen progress bar represents
+ * progress within the current chapter, not the full book.
+ */
+
+import { formatTime } from "@/lib/helpers/formatters";
+import { configureTrackPlayer } from "@/lib/trackPlayerConfig";
+import { logger } from "@/lib/logger";
+import type { ChapterRow } from "@/types/database";
+import type { PlayerTrack } from "@/types/player";
+import TrackPlayer from "react-native-track-player";
+
+const log = logger.forTag("NowPlayingMetadata");
+
+/**
+ * Find the chapter that contains `position` (seconds from the start of the book).
+ * Clamps to the first or last chapter when the position falls outside all known ranges.
+ */
+function resolveChapterAtPosition(chapters: ChapterRow[], position: number): ChapterRow {
+  const inRange = chapters.find((c) => position >= c.start && position < c.end);
+  if (inRange) return inRange;
+  return position >= chapters[chapters.length - 1].end ? chapters[chapters.length - 1] : chapters[0];
+}
+
+/**
+ * Push chapter-relative metadata to the iOS/Android now-playing center.
+ *
+ * @param track  The currently loaded PlayerTrack (provides chapters, title, author, artwork).
+ * @param position  Absolute playback position in seconds (from the start of the book).
+ */
+export async function updateNowPlayingMetadata(
+  track: PlayerTrack,
+  position: number
+): Promise<void> {
+  if (!track.chapters?.length) {
+    log.debug("[updateNowPlayingMetadata] No chapters, skipping");
+    return;
+  }
+
+  const chapter = resolveChapterAtPosition(track.chapters, position);
+  const chapterDuration = Math.max(0, chapter.end - chapter.start);
+  const elapsedTime = Math.max(0, Math.min(chapterDuration, position - chapter.start));
+
+  log.debug(
+    `[updateNowPlayingMetadata] track=${track.libraryItemId} chapter=${chapter.id} elapsed=${formatTime(elapsedTime)}/${formatTime(chapterDuration)}`
+  );
+
+  const activeTrackIndex = await TrackPlayer.getActiveTrackIndex();
+  if (activeTrackIndex == null || activeTrackIndex < 0) {
+    log.warn("[updateNowPlayingMetadata] No active track index, skipping");
+    return;
+  }
+
+  await TrackPlayer.updateMetadataForTrack(activeTrackIndex, {
+    title: chapter.title,
+    artist: track.author,
+    album: track.title,
+    artwork: track.coverUri || undefined,
+    duration: chapterDuration,
+    // @ts-ignore — elapsedTime is consumed by iOS native code (Metadata.swift) but absent from the TS types
+    elapsedTime,
+  });
+
+  // Re-apply capabilities after metadata update to prevent lock screen controls from disappearing.
+  await configureTrackPlayer();
+
+  log.debug(
+    `[updateNowPlayingMetadata] Updated: chapter="${chapter.title}" ${formatTime(elapsedTime)}/${formatTime(chapterDuration)}`
+  );
+}

--- a/src/services/__tests__/BackgroundReconnectCollaborator.test.ts
+++ b/src/services/__tests__/BackgroundReconnectCollaborator.test.ts
@@ -17,8 +17,13 @@ import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals
 import TrackPlayer from "react-native-track-player";
 import type { IPlayerServiceFacade } from "@/services/player/types";
 import { BackgroundReconnectCollaborator } from "@/services/player/BackgroundReconnectCollaborator";
+import { updateNowPlayingMetadata } from "@/lib/nowPlayingMetadata";
 
 // --- Mocks ---
+
+jest.mock("@/lib/nowPlayingMetadata", () => ({
+  updateNowPlayingMetadata: jest.fn(() => Promise.resolve()),
+}));
 
 jest.mock("react-native-track-player", () => ({
   registerPlaybackService: jest.fn(),
@@ -69,9 +74,9 @@ describe("BackgroundReconnectCollaborator", () => {
   const mockStore = {
     player: {
       currentTrack: null as any,
+      position: 0,
     },
     _setCurrentTrack: jest.fn(),
-    updateNowPlayingMetadata: jest.fn(),
   };
 
   beforeEach(() => {
@@ -153,19 +158,15 @@ describe("BackgroundReconnectCollaborator", () => {
       };
       const newCoverUri = "file:///new-container/covers/item-1.jpg";
       getCoverUri.mockReturnValue(newCoverUri);
-      // updateNowPlayingMetadata is a store method
-      mockStore.updateNowPlayingMetadata.mockResolvedValue(undefined);
-      useAppStore.getState
-        .mockReturnValueOnce(mockStore) // first getState call
-        .mockReturnValueOnce({
-          ...mockStore,
-          updateNowPlayingMetadata: mockStore.updateNowPlayingMetadata,
-        }); // second for updateNowPlayingMetadata
 
       await collaborator.refreshFilePathsAfterContainerChange();
 
       expect(mockStore._setCurrentTrack).toHaveBeenCalledWith(
         expect.objectContaining({ coverUri: newCoverUri })
+      );
+      expect(updateNowPlayingMetadata as jest.Mock).toHaveBeenCalledWith(
+        expect.objectContaining({ coverUri: newCoverUri }),
+        0
       );
     });
 

--- a/src/services/coordinator/PlayerStateCoordinator.ts
+++ b/src/services/coordinator/PlayerStateCoordinator.ts
@@ -27,6 +27,7 @@ import { getUserByUsername } from "@/db/helpers/users";
 import { ASYNC_KEYS, getItem as getAsyncItem, saveItem } from "@/lib/asyncStore";
 import { formatTime } from "@/lib/helpers/formatters";
 import { logger } from "@/lib/logger";
+import { updateNowPlayingMetadata } from "@/lib/nowPlayingMetadata";
 import { getStoredUsername } from "@/lib/secureStore";
 import { useAppStore } from "@/stores/appStore";
 import {
@@ -914,13 +915,20 @@ export class PlayerStateCoordinator extends EventEmitter {
         this._pendingProgressJump = null;
       }
 
-      // Detect chapter boundary crossings; debounced by lastSyncedChapterId (mirrors PROP-06)
+      // Detect chapter boundary crossings using the store's computed chapter id (set
+      // synchronously by _updateCurrentChapter above). Debounced by lastSyncedChapterId.
       const currentChapterId = store.player.currentChapter?.chapter?.id?.toString() ?? null;
       if (currentChapterId !== null && currentChapterId !== this.lastSyncedChapterId) {
         this.lastSyncedChapterId = currentChapterId;
-        store.updateNowPlayingMetadata().catch((err) => {
-          log.error("[Coordinator] Failed to update now playing metadata on chapter change", err);
-        });
+        // currentTrack comes from the store (maintained by PlayerService); position
+        // comes from this.context (coordinator's authoritative value, not delayed by
+        // the React state cycle).
+        const track = store.player.currentTrack;
+        if (track && !this.context.isLoadingTrack) {
+          updateNowPlayingMetadata(track, this.context.position).catch((err) => {
+            log.error("[Coordinator] Failed to update now playing metadata on chapter change", err);
+          });
+        }
       }
     } catch {
       // BGS headless context: Zustand store may not be available (PROP-05)
@@ -972,8 +980,15 @@ export class PlayerStateCoordinator extends EventEmitter {
       // absolute track position when playback state changes, overwriting the chapter-relative
       // elapsedTime we set. Re-asserting our metadata after these transitions ensures the lock
       // screen always freezes (PAUSE) or resumes advancing (PLAY) from the correct chapter position.
-      if (event.type === "SEEK_COMPLETE" || event.type === "PAUSE" || event.type === "PLAY") {
-        store.updateNowPlayingMetadata().catch((err) => {
+      // currentTrack comes from the store (maintained by PlayerService); position
+      // comes from this.context (coordinator's authoritative value).
+      const track = store.player.currentTrack;
+      if (
+        (event.type === "SEEK_COMPLETE" || event.type === "PAUSE" || event.type === "PLAY") &&
+        track &&
+        !this.context.isLoadingTrack
+      ) {
+        updateNowPlayingMetadata(track, this.context.position).catch((err) => {
           log.error("[Coordinator] Failed to update now playing metadata", err);
         });
       }

--- a/src/services/coordinator/PlayerStateCoordinator.ts
+++ b/src/services/coordinator/PlayerStateCoordinator.ts
@@ -896,7 +896,7 @@ export class PlayerStateCoordinator extends EventEmitter {
    * synchronously via Zustand set, so store.player.currentChapter reflects the
    * updated chapter by the time the comparison runs.
    *
-   * Debounced by lastSyncedChapterId (mirrors PROP-06 in syncStateToStore).
+   * Debounced by lastSyncedChapterId to avoid redundant metadata updates.
    *
    * Guard: no-op when Zustand is unavailable (Android BGS headless context, PROP-05).
    */
@@ -939,8 +939,9 @@ export class PlayerStateCoordinator extends EventEmitter {
    * responsibility for building and setting PlayerTrack objects (Plan 02 documented
    * exception - coordinator cannot build PlayerTrack).
    *
-   * After sync, if the current chapter changed, calls updateNowPlayingMetadata()
-   * fire-and-forget (PROP-06: only on actual chapter change, not every structural sync).
+   * After sync, calls updateNowPlayingMetadata() fire-and-forget on SEEK_COMPLETE,
+   * PAUSE, and PLAY to keep the lock screen position accurate at key transitions.
+   * Chapter boundary crossings are handled by syncPositionToStore instead (CLEAN-03).
    *
    * Guard: no-op when Zustand is unavailable (Android BGS headless context, PROP-05).
    */
@@ -960,26 +961,20 @@ export class PlayerStateCoordinator extends EventEmitter {
       store._setVolume(this.context.volume);
       store._setPlaySessionId(this.context.sessionId);
 
-      // PROP-06: Only call updateNowPlayingMetadata when chapter actually changes
-      const currentChapterId = this.context.currentChapter?.chapter?.id?.toString() ?? null;
-      if (currentChapterId !== null && currentChapterId !== this.lastSyncedChapterId) {
-        this.lastSyncedChapterId = currentChapterId;
+      // Refresh lock screen metadata at key playback state transitions.
+      // Chapter boundary crossings are handled in syncPositionToStore (CLEAN-03), which
+      // reads the chapter from the store after updatePosition() runs _updateCurrentChapter.
+      //
+      // SEEK_COMPLETE: same-chapter seeks change positionInChapter without triggering a
+      // chapter boundary crossing, so syncPositionToStore's chapter detector won't fire.
+      //
+      // PAUSE / PLAY: TrackPlayer's native layer updates MPNowPlayingInfoCenter with the
+      // absolute track position when playback state changes, overwriting the chapter-relative
+      // elapsedTime we set. Re-asserting our metadata after these transitions ensures the lock
+      // screen always freezes (PAUSE) or resumes advancing (PLAY) from the correct chapter position.
+      if (event.type === "SEEK_COMPLETE" || event.type === "PAUSE" || event.type === "PLAY") {
         store.updateNowPlayingMetadata().catch((err) => {
           log.error("[Coordinator] Failed to update now playing metadata", err);
-        });
-      }
-
-      // SKIP-02: On seek completion, refresh lock screen elapsed time unconditionally.
-      // Same-chapter skips do not change currentChapterId, so PROP-06 guard above won't fire.
-      // updateNowPlayingMetadata reads positionInChapter from store.player.currentChapter,
-      // which is up-to-date because updatePosition() (called via syncPositionToStore on
-      // NATIVE_PROGRESS_UPDATED) runs _updateCurrentChapter synchronously.
-      // The coordinator bridge calls syncStateToStore after every allowed transition —
-      // SEEK_COMPLETE arrives here after TrackPlayer.seekTo resolves and the event
-      // passes the SEEKING→READY transition guard.
-      if (event.type === "SEEK_COMPLETE") {
-        store.updateNowPlayingMetadata().catch((err) => {
-          log.error("[Coordinator] Failed to update now playing metadata after seek", err);
         });
       }
     } catch {

--- a/src/services/coordinator/__tests__/PlayerStateCoordinator.test.ts
+++ b/src/services/coordinator/__tests__/PlayerStateCoordinator.test.ts
@@ -2417,58 +2417,70 @@ describe("PlayerStateCoordinator", () => {
     });
 
     // --------------------------------------------------------------------------
-    // PROP-06: updateNowPlayingMetadata debounce preserved
+    // Lock screen metadata updated on PAUSE / PLAY / SEEK_COMPLETE
     //
-    // updateNowPlayingMetadata is only called when chapter.id changes (not every
-    // structural sync). This prevents redundant now-playing updates at each event.
-    //
-    // Note: Periodic metadata updates (2s gate) are preserved in BGS
-    // handlePlaybackProgressUpdated — not tested here as that's BGS-specific.
+    // syncStateToStore calls updateNowPlayingMetadata on these three event types
+    // so the lock screen position is accurate when iOS freezes (PAUSE), resumes
+    // (PLAY), or the user seeks within the same chapter (SEEK_COMPLETE).
+    // Chapter boundary crossings are handled separately in syncPositionToStore.
     // --------------------------------------------------------------------------
 
-    describe("PROP-06: updateNowPlayingMetadata debounce preserved", () => {
-      it("should call updateNowPlayingMetadata once on chapter change, not again for same chapter", async () => {
-        // Reach PLAYING state
-        await coordinator.dispatch({
-          type: "LOAD_TRACK",
-          payload: { libraryItemId: "prop-06-item" },
-        });
-        await coordinator.dispatch({
-          type: "QUEUE_RELOADED",
-          payload: { position: 0 },
-        });
+    describe("lock screen metadata updated at key playback transitions", () => {
+      it("calls updateNowPlayingMetadata on PAUSE", async () => {
+        await coordinator.dispatch({ type: "LOAD_TRACK", payload: { libraryItemId: "item-1" } });
+        await coordinator.dispatch({ type: "QUEUE_RELOADED", payload: { position: 0 } });
         await coordinator.dispatch({ type: "PLAY" });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        // Reset mocks
         jest.clearAllMocks();
         mockStore = makeMockStore();
         useAppStore.getState.mockReturnValue(mockStore);
 
-        const chapter1: any = {
-          chapter: {
-            id: "chapter-1",
-            chapterId: 1,
-            title: "Chapter 1",
-            start: 0,
-            end: 600,
-            mediaId: "media-1",
-          },
-          positionInChapter: 0,
-          chapterDuration: 600,
-        };
-
-        // Dispatch CHAPTER_CHANGED with chapter 1
-        await coordinator.dispatch({
-          type: "CHAPTER_CHANGED",
-          payload: { chapter: chapter1 },
-        });
+        await coordinator.dispatch({ type: "PAUSE" });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        // updateNowPlayingMetadata called once for the chapter change
         expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
+      });
 
-        // Reset mocks and dispatch NATIVE_PROGRESS_UPDATED (same chapter, no change)
+      it("calls updateNowPlayingMetadata on PLAY (resume)", async () => {
+        await coordinator.dispatch({ type: "LOAD_TRACK", payload: { libraryItemId: "item-1" } });
+        await coordinator.dispatch({ type: "QUEUE_RELOADED", payload: { position: 0 } });
+        await coordinator.dispatch({ type: "PLAY" });
+        await coordinator.dispatch({ type: "PAUSE" });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        jest.clearAllMocks();
+        mockStore = makeMockStore();
+        useAppStore.getState.mockReturnValue(mockStore);
+
+        await coordinator.dispatch({ type: "PLAY" });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
+      });
+
+      it("does NOT call updateNowPlayingMetadata on SET_RATE or other structural events", async () => {
+        await coordinator.dispatch({ type: "LOAD_TRACK", payload: { libraryItemId: "item-1" } });
+        await coordinator.dispatch({ type: "QUEUE_RELOADED", payload: { position: 0 } });
+        await coordinator.dispatch({ type: "PLAY" });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        jest.clearAllMocks();
+        mockStore = makeMockStore();
+        useAppStore.getState.mockReturnValue(mockStore);
+
+        await coordinator.dispatch({ type: "SET_RATE", payload: { rate: 1.5 } });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(mockStore.updateNowPlayingMetadata).not.toHaveBeenCalled();
+      });
+
+      it("does NOT call updateNowPlayingMetadata on NATIVE_PROGRESS_UPDATED (position-only path)", async () => {
+        await coordinator.dispatch({ type: "LOAD_TRACK", payload: { libraryItemId: "item-1" } });
+        await coordinator.dispatch({ type: "QUEUE_RELOADED", payload: { position: 0 } });
+        await coordinator.dispatch({ type: "PLAY" });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
         jest.clearAllMocks();
         mockStore = makeMockStore();
         useAppStore.getState.mockReturnValue(mockStore);
@@ -2479,35 +2491,7 @@ describe("PlayerStateCoordinator", () => {
         });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        // updateNowPlayingMetadata must NOT be called (same chapter, position-only path)
         expect(mockStore.updateNowPlayingMetadata).not.toHaveBeenCalled();
-
-        // Reset mocks and dispatch a different chapter
-        jest.clearAllMocks();
-        mockStore = makeMockStore();
-        useAppStore.getState.mockReturnValue(mockStore);
-
-        const chapter2: any = {
-          chapter: {
-            id: "chapter-2",
-            chapterId: 2,
-            title: "Chapter 2",
-            start: 600,
-            end: 1200,
-            mediaId: "media-1",
-          },
-          positionInChapter: 0,
-          chapterDuration: 600,
-        };
-
-        await coordinator.dispatch({
-          type: "CHAPTER_CHANGED",
-          payload: { chapter: chapter2 },
-        });
-        await new Promise((resolve) => setTimeout(resolve, 50));
-
-        // updateNowPlayingMetadata called again for the new chapter
-        expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -2660,41 +2644,25 @@ describe("PlayerStateCoordinator", () => {
       expect(mockStore._setLastPauseTime).not.toHaveBeenCalled();
     });
 
-    it("syncToStore calls updateNowPlayingMetadata on chapter change", async () => {
+    it("syncStateToStore calls updateNowPlayingMetadata on PAUSE but not SET_RATE", async () => {
       // Reach PLAYING state
       await coordinator.dispatch({ type: "LOAD_TRACK", payload: { libraryItemId: "test-item" } });
       await coordinator.dispatch({ type: "QUEUE_RELOADED", payload: { position: 0 } });
       await coordinator.dispatch({ type: "PLAY" });
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // Reset mocks to count only the chapter-change-triggered call
+      // Reset mocks to isolate
       jest.clearAllMocks();
       mockStore = makeMockStore();
       useAppStore.getState.mockReturnValue(mockStore);
 
-      // Dispatch CHAPTER_CHANGED with a properly-structured CurrentChapter payload
-      const mockCurrentChapter: any = {
-        chapter: {
-          id: "ch-1",
-          chapterId: 1,
-          title: "Chapter 1",
-          start: 0,
-          end: 600,
-          mediaId: "m1",
-        },
-        positionInChapter: 0,
-        chapterDuration: 600,
-      };
-      await coordinator.dispatch({
-        type: "CHAPTER_CHANGED",
-        payload: { chapter: mockCurrentChapter },
-      });
+      await coordinator.dispatch({ type: "PAUSE" });
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // updateNowPlayingMetadata called once for the chapter change
+      // updateNowPlayingMetadata called once for the PAUSE transition
       expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
 
-      // Dispatch another structural event that does NOT change the chapter
+      // Dispatch a structural event that does NOT warrant a metadata update
       jest.clearAllMocks();
       mockStore = makeMockStore();
       useAppStore.getState.mockReturnValue(mockStore);
@@ -2702,7 +2670,7 @@ describe("PlayerStateCoordinator", () => {
       await coordinator.dispatch({ type: "SET_RATE", payload: { rate: 1.5 } });
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // updateNowPlayingMetadata must NOT be called again (same chapter id)
+      // updateNowPlayingMetadata must NOT be called for SET_RATE
       expect(mockStore.updateNowPlayingMetadata).not.toHaveBeenCalled();
     });
 

--- a/src/services/coordinator/__tests__/PlayerStateCoordinator.test.ts
+++ b/src/services/coordinator/__tests__/PlayerStateCoordinator.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals
 import { State } from "react-native-track-player";
 import { PlayerStateCoordinator } from "../PlayerStateCoordinator";
 import { playerEventBus } from "../eventBus";
+import { updateNowPlayingMetadata } from "@/lib/nowPlayingMetadata";
 
 // Mock PlayerService
 jest.mock("../../PlayerService", () => {
@@ -76,6 +77,11 @@ jest.mock("@/stores/appStore", () => ({
 // Mock traceDump — expo-application is not installed in the test environment
 jest.mock("@/lib/traceDump", () => ({
   writeDumpToDisk: jest.fn(() => Promise.resolve("file://mock-dump.json")),
+}));
+
+// Mock the now-playing lib so tests don't need a live TrackPlayer instance
+jest.mock("@/lib/nowPlayingMetadata", () => ({
+  updateNowPlayingMetadata: jest.fn(() => Promise.resolve()),
 }));
 
 // Mock logger
@@ -2184,7 +2190,12 @@ describe("PlayerStateCoordinator", () => {
     const { useAppStore } = require("@/stores/appStore");
 
     const makeMockStore = () => ({
-      player: { position: 0 },
+      player: {
+        position: 0,
+        // currentTrack must be non-null so the coordinator's updateNowPlayingMetadata
+        // guard passes (track && !isLoadingTrack).
+        currentTrack: { libraryItemId: "test-item", chapters: [], title: "Test", author: "Author", coverUri: null, duration: 3600 },
+      },
       updatePosition: jest.fn(),
       updatePlayingState: jest.fn(),
       _setCurrentTrack: jest.fn(),
@@ -2195,7 +2206,6 @@ describe("PlayerStateCoordinator", () => {
       _setPlaySessionId: jest.fn(),
       _setLastPauseTime: jest.fn(),
       _setPendingProgressJump: jest.fn(),
-      updateNowPlayingMetadata: jest.fn().mockResolvedValue(undefined),
       setSleepTimer: jest.fn(),
       cancelSleepTimer: jest.fn(),
     });
@@ -2439,7 +2449,7 @@ describe("PlayerStateCoordinator", () => {
         await coordinator.dispatch({ type: "PAUSE" });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
+        expect((updateNowPlayingMetadata as jest.Mock)).toHaveBeenCalledTimes(1);
       });
 
       it("calls updateNowPlayingMetadata on PLAY (resume)", async () => {
@@ -2456,7 +2466,7 @@ describe("PlayerStateCoordinator", () => {
         await coordinator.dispatch({ type: "PLAY" });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
+        expect((updateNowPlayingMetadata as jest.Mock)).toHaveBeenCalledTimes(1);
       });
 
       it("does NOT call updateNowPlayingMetadata on SET_RATE or other structural events", async () => {
@@ -2472,7 +2482,7 @@ describe("PlayerStateCoordinator", () => {
         await coordinator.dispatch({ type: "SET_RATE", payload: { rate: 1.5 } });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        expect(mockStore.updateNowPlayingMetadata).not.toHaveBeenCalled();
+        expect((updateNowPlayingMetadata as jest.Mock)).not.toHaveBeenCalled();
       });
 
       it("does NOT call updateNowPlayingMetadata on NATIVE_PROGRESS_UPDATED (position-only path)", async () => {
@@ -2491,7 +2501,7 @@ describe("PlayerStateCoordinator", () => {
         });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        expect(mockStore.updateNowPlayingMetadata).not.toHaveBeenCalled();
+        expect((updateNowPlayingMetadata as jest.Mock)).not.toHaveBeenCalled();
       });
     });
   });
@@ -2505,7 +2515,12 @@ describe("PlayerStateCoordinator", () => {
 
     // Create a mock store with all playerSlice mutators as jest.fn() spies
     const makeMockStore = () => ({
-      player: { position: 0 },
+      player: {
+        position: 0,
+        // currentTrack must be non-null so the coordinator's updateNowPlayingMetadata
+        // guard passes (track && !isLoadingTrack).
+        currentTrack: { libraryItemId: "test-item", chapters: [], title: "Test", author: "Author", coverUri: null, duration: 3600 },
+      },
       updatePosition: jest.fn(),
       updatePlayingState: jest.fn(),
       _setCurrentTrack: jest.fn(),
@@ -2516,7 +2531,6 @@ describe("PlayerStateCoordinator", () => {
       _setPlaySessionId: jest.fn(),
       _setLastPauseTime: jest.fn(),
       _setPendingProgressJump: jest.fn(),
-      updateNowPlayingMetadata: jest.fn().mockResolvedValue(undefined),
       setSleepTimer: jest.fn(),
       cancelSleepTimer: jest.fn(),
     });
@@ -2585,7 +2599,7 @@ describe("PlayerStateCoordinator", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // Assert updateNowPlayingMetadata called once for the chapter change
-      expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
+      expect((updateNowPlayingMetadata as jest.Mock)).toHaveBeenCalledTimes(1);
 
       // Reset mocks — dispatch again with SAME chapter (no change expected)
       jest.clearAllMocks();
@@ -2600,7 +2614,7 @@ describe("PlayerStateCoordinator", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // Debounce: same chapter id — updateNowPlayingMetadata must NOT be called again
-      expect(mockStore.updateNowPlayingMetadata).not.toHaveBeenCalled();
+      expect((updateNowPlayingMetadata as jest.Mock)).not.toHaveBeenCalled();
     });
 
     it("syncStateToStore updates all fields on structural transition (LOAD_TRACK)", async () => {
@@ -2660,7 +2674,7 @@ describe("PlayerStateCoordinator", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // updateNowPlayingMetadata called once for the PAUSE transition
-      expect(mockStore.updateNowPlayingMetadata).toHaveBeenCalledTimes(1);
+      expect((updateNowPlayingMetadata as jest.Mock)).toHaveBeenCalledTimes(1);
 
       // Dispatch a structural event that does NOT warrant a metadata update
       jest.clearAllMocks();
@@ -2671,7 +2685,7 @@ describe("PlayerStateCoordinator", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // updateNowPlayingMetadata must NOT be called for SET_RATE
-      expect(mockStore.updateNowPlayingMetadata).not.toHaveBeenCalled();
+      expect((updateNowPlayingMetadata as jest.Mock)).not.toHaveBeenCalled();
     });
 
     it("syncToStore handles BGS context gracefully when getState throws", async () => {

--- a/src/services/player/BackgroundReconnectCollaborator.ts
+++ b/src/services/player/BackgroundReconnectCollaborator.ts
@@ -14,6 +14,7 @@
 import { getCoverUri } from "@/lib/covers";
 import { configureTrackPlayer } from "@/lib/trackPlayerConfig";
 import { logger } from "@/lib/logger";
+import { updateNowPlayingMetadata } from "@/lib/nowPlayingMetadata";
 import { useAppStore } from "@/stores/appStore";
 import type { PlayerTrack } from "@/types/player";
 import { AppState } from "react-native";
@@ -160,9 +161,10 @@ export class BackgroundReconnectCollaborator implements IBackgroundReconnectColl
 
         store._setCurrentTrack(updatedTrack);
 
-        // Update TrackPlayer's now playing metadata with the new cover URI
-        // This ensures the lock screen and notification show the correct cover
-        await useAppStore.getState().updateNowPlayingMetadata();
+        // Update TrackPlayer's now playing metadata with the new cover URI so
+        // the lock screen and notification show the correct cover.
+        const position = useAppStore.getState().player.position;
+        await updateNowPlayingMetadata(updatedTrack, position);
 
         log.info("[PlayerService] Track metadata refreshed with new cover URI");
       } else {

--- a/src/stores/slices/__tests__/playerSlice.test.ts
+++ b/src/stores/slices/__tests__/playerSlice.test.ts
@@ -22,9 +22,6 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
 jest.mock("react-native-track-player", () => ({
   getQueue: jest.fn(),
   seekTo: jest.fn(),
-  getActiveTrackIndex: jest.fn(),
-  getActiveTrack: jest.fn(),
-  updateMetadataForTrack: jest.fn(),
 }));
 
 // Mock ProgressService
@@ -44,10 +41,6 @@ jest.mock("../../../lib/secureStore", () => ({
   getStoredUsername: jest.fn(),
 }));
 
-// Mock track player config
-jest.mock("../../../lib/trackPlayerConfig", () => ({
-  configureTrackPlayer: jest.fn(),
-}));
 
 describe("PlayerSlice", () => {
   let store: UseBoundStore<StoreApi<PlayerSlice>>;
@@ -58,7 +51,6 @@ describe("PlayerSlice", () => {
   const mockedProgressService = progressService as jest.Mocked<typeof progressService>;
   const { getUserByUsername } = require("../../../db/helpers/users");
   const { getStoredUsername } = require("../../../lib/secureStore");
-  const { configureTrackPlayer } = require("../../../lib/trackPlayerConfig");
 
   // Mock player track data
   const mockPlayerTrack: PlayerTrack = {
@@ -105,13 +97,9 @@ describe("PlayerSlice", () => {
     mockedAsyncStorage.setItem.mockResolvedValue();
     mockedTrackPlayer.getQueue.mockResolvedValue([]);
     mockedTrackPlayer.seekTo.mockResolvedValue();
-    mockedTrackPlayer.getActiveTrackIndex.mockResolvedValue(0);
-    mockedTrackPlayer.getActiveTrack.mockResolvedValue(undefined);
-    mockedTrackPlayer.updateMetadataForTrack.mockResolvedValue();
     mockedProgressService.getCurrentSession.mockResolvedValue(null);
     getUserByUsername.mockResolvedValue({ id: "user-1" });
     getStoredUsername.mockResolvedValue("testuser");
-    configureTrackPlayer.mockResolvedValue();
   });
 
   afterEach(() => {
@@ -512,74 +500,6 @@ describe("PlayerSlice", () => {
         const remaining = store.getState().getSleepTimerRemaining();
         expect(remaining).toBeNull();
       });
-    });
-  });
-
-  describe("updateNowPlayingMetadata", () => {
-    it("should update TrackPlayer metadata with chapter info", async () => {
-      store.getState()._setCurrentTrack(mockPlayerTrack);
-      store.getState().updatePosition(100);
-
-      mockedTrackPlayer.getActiveTrackIndex.mockResolvedValue(0);
-      mockedTrackPlayer.getActiveTrack.mockResolvedValue({
-        id: "track-1",
-        title: "Test",
-        url: "test-url",
-      });
-
-      await store.getState().updateNowPlayingMetadata();
-
-      expect(mockedTrackPlayer.updateMetadataForTrack).toHaveBeenCalledWith(
-        0,
-        expect.objectContaining({
-          title: "Chapter 1",
-          artist: "Test Author",
-          album: "Test Book",
-          artwork: "file:///test-cover.jpg",
-          duration: 1800,
-          elapsedTime: 100,
-        })
-      );
-    });
-
-    it("should skip update when no track is loaded", async () => {
-      await store.getState().updateNowPlayingMetadata();
-
-      expect(mockedTrackPlayer.updateMetadataForTrack).not.toHaveBeenCalled();
-    });
-
-    it("should skip update when no chapter is set", async () => {
-      const trackWithoutChapters = { ...mockPlayerTrack, chapters: [] };
-      store.getState()._setCurrentTrack(trackWithoutChapters);
-
-      await store.getState().updateNowPlayingMetadata();
-
-      expect(mockedTrackPlayer.updateMetadataForTrack).not.toHaveBeenCalled();
-    });
-
-    it("should handle errors gracefully", async () => {
-      store.getState()._setCurrentTrack(mockPlayerTrack);
-      store.getState().updatePosition(100);
-
-      mockedTrackPlayer.getActiveTrackIndex.mockRejectedValue(new Error("TrackPlayer error"));
-
-      await expect(store.getState().updateNowPlayingMetadata()).resolves.not.toThrow();
-    });
-
-    it("should reconfigure TrackPlayer after metadata update", async () => {
-      store.getState()._setCurrentTrack(mockPlayerTrack);
-      store.getState().updatePosition(100);
-
-      mockedTrackPlayer.getActiveTrackIndex.mockResolvedValue(0);
-      mockedTrackPlayer.getActiveTrack.mockResolvedValue({
-        id: "track-1",
-        title: "Test",
-        url: "test-url",
-      });
-
-      await store.getState().updateNowPlayingMetadata();
-
-      expect(configureTrackPlayer).toHaveBeenCalled();
     });
   });
 

--- a/src/stores/slices/playerSlice.ts
+++ b/src/stores/slices/playerSlice.ts
@@ -13,7 +13,6 @@ import { ASYNC_KEYS, getItem as getAsyncItem, saveItem } from "@/lib/asyncStore"
 import { formatTime } from "@/lib/helpers/formatters";
 import { logger } from "@/lib/logger";
 import { getStoredUsername } from "@/lib/secureStore";
-import { configureTrackPlayer } from "@/lib/trackPlayerConfig";
 import { progressService } from "@/services/ProgressService";
 import { dispatchPlayerEvent } from "@/services/coordinator/eventBus";
 import type { CurrentChapter, PlayerTrack } from "@/types/player";
@@ -114,8 +113,6 @@ export interface PlayerSliceActions {
   _setPendingProgressJump: (
     jump: { fromPosition: number; toPosition: number; timestamp: number } | null
   ) => void;
-  /** Update now playing metadata with chapter information */
-  updateNowPlayingMetadata: () => Promise<void>;
   /** Set sleep timer with duration in minutes */
   setSleepTimer: (minutes: number) => void;
   /** Set sleep timer to end at chapter boundary */
@@ -582,71 +579,6 @@ export const createPlayerSlice: SliceCreator<PlayerSlice> = (set, get) => ({
     set((state) => ({ player: { ...state.player, pendingProgressJump: jump } }));
   },
 
-  /**
-   * Update now playing metadata with chapter information
-   *
-   * Updates the now playing center with:
-   * - Title: Current chapter title
-   * - Album: Book title
-   * - Duration: Chapter duration (so progress bar shows chapter progress)
-   * - Elapsed time: Chapter-relative position (resets to 0 at start of each chapter)
-   *
-   * Note: TrackPlayer's actual playback position is always absolute (book position),
-   * but we set elapsedTime to chapter-relative position so the now playing center
-   * shows progress within the current chapter.
-   */
-  updateNowPlayingMetadata: async () => {
-    try {
-      const state = get();
-      const { currentTrack, currentChapter } = state.player;
-      if (!currentTrack || !currentChapter) {
-        log.debug("Skipping now playing metadata update - missing track or chapter");
-        return;
-      }
-
-      log.debug(
-        `Updating now playing metadata for track=${currentTrack.libraryItemId} chapter=${currentChapter.chapter.id}`
-      );
-
-      // Use chapter-relative position for elapsed time
-      // positionInChapter is calculated as: absolutePosition - chapter.start
-      const chapterElapsedTime = currentChapter.positionInChapter;
-      const chapterDuration = currentChapter.chapterDuration;
-      const chapterTitle = currentChapter.chapter.title;
-      const bookTitle = currentTrack.title;
-      const author = currentTrack.author;
-
-      // Get the active track index to update its metadata
-      const activeTrackIndex = await TrackPlayer.getActiveTrackIndex();
-      if (activeTrackIndex === undefined || activeTrackIndex === null || activeTrackIndex < 0) {
-        log.warn("Cannot update now playing metadata - no active track index");
-        return;
-      }
-
-      const activeTrack = await TrackPlayer.getActiveTrack();
-      // Update now playing metadata with chapter info
-      // TrackPlayer will use this for the lock screen and notification controls
-      await TrackPlayer.updateMetadataForTrack(activeTrackIndex, {
-        title: chapterTitle,
-        artist: author,
-        album: bookTitle,
-        // Always set artwork when available to ensure it displays
-        artwork: currentTrack.coverUri || undefined,
-        duration: chapterDuration,
-        // @ts-ignore - elapsedTime is used by iOS native code (Metadata.swift) but not in TypeScript types
-        elapsedTime: chapterElapsedTime,
-      });
-
-      // Double check that we don't lose the trackplayer controls on the lock screen
-      await configureTrackPlayer();
-
-      log.debug(
-        `Updated now playing: chapter="${chapterTitle}" elapsed=${formatTime(chapterElapsedTime)}/${formatTime(chapterDuration)}`
-      );
-    } catch (error) {
-      log.error("Failed to update now playing metadata:", error as Error);
-    }
-  },
 
   setSleepTimer: (minutes: number) => {
     const endTime = Date.now() + minutes * 60 * 1000;


### PR DESCRIPTION
## Summary
Refactored `updateNowPlayingMetadata` from a Zustand store method into a pure, standalone library function. This decouples lock screen metadata updates from React state management, enabling the coordinator to call it directly with authoritative position data without waiting for the state cycle.

## Key Changes

- **New library function** (`src/lib/nowPlayingMetadata.ts`): Pure function that accepts explicit `track` and `position` parameters, calculates chapter-relative metadata, and updates TrackPlayer. No store dependencies.

- **Removed from playerSlice**: Deleted `updateNowPlayingMetadata` action from the Zustand store. Tests for this method moved to the new library test file.

- **Updated PlayerStateCoordinator**: 
  - Now calls the library function directly instead of `store.updateNowPlayingMetadata()`
  - Passes `this.context.position` (coordinator's authoritative value) instead of relying on store state
  - Calls metadata update on three key events: `SEEK_COMPLETE`, `PAUSE`, and `PLAY` to keep lock screen position accurate at playback transitions
  - Chapter boundary crossings still handled by `syncPositionToStore` (debounced by `lastSyncedChapterId`)

- **Updated BackgroundReconnectCollaborator**: Calls the library function directly when reconnecting with a new cover URI.

- **Test updates**:
  - New comprehensive test suite for `updateNowPlayingMetadata` library function
  - Coordinator tests refactored to mock the library function instead of store method
  - Removed store method tests from playerSlice tests
  - Updated mock stores to remove the method

## Implementation Details

The library function:
- Resolves the current chapter from the track's chapter list based on absolute position
- Calculates chapter-relative elapsed time (position - chapter.start)
- Updates TrackPlayer metadata with chapter title, duration, and elapsed time
- Calls `configureTrackPlayer()` after update to preserve lock screen controls
- Gracefully skips when track has no chapters or no active track index

This approach eliminates the one-tick lag that occurred when reading from Zustand state and ensures the coordinator always uses its own authoritative position value for metadata updates.

https://claude.ai/code/session_015mddkYuwoDxZj2Ex8zAWNn